### PR TITLE
refactor and add regexp log format support

### DIFF
--- a/docker-images/fluentd.tpl
+++ b/docker-images/fluentd.tpl
@@ -4,7 +4,12 @@
   tag {{ $.containerId }}.{{ .Name }}
   path {{ .HostDir }}/{{ .File }}
   format {{ .Format }}
-  {{if .TimeFormat}} time_format {{ .TimeFormat }}  {{end}}
+
+{{if .FormatConfig}}
+{{range $key, $value := .FormatConfig}}
+{{ $key }} {{ $value }}
+{{end}}
+{{end}}
   pos_file /pilot/pos/fluentd.pos
   refresh_interval 5
 </source>

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	log "github.com/sirupsen/logrus"
 	"os"
-	"github.com/jzwlqx/fluent-pilot/pilot"
+	"github.com/jzwlqx/fluentd-pilot/pilot"
 )
 
 func main() {

--- a/pilot/format.go
+++ b/pilot/format.go
@@ -1,0 +1,62 @@
+package pilot
+
+import "fmt"
+
+type FormatConverter func(info *LogInfoNode) (map[string]string, error)
+
+var converters = make(map[string]FormatConverter)
+
+func Register(format string, converter FormatConverter) {
+	converters[format] = converter
+}
+
+func Convert(info *LogInfoNode) (map[string]string, error) {
+	converter := converters[info.value]
+	if converter == nil {
+		return nil, fmt.Errorf("unsupported log format: %s", info.value)
+	}
+	return converter(info)
+}
+
+type SimpleConverter struct {
+	properties map[string]bool
+}
+
+func init() {
+
+	simpleConverter := func(properties []string) FormatConverter {
+		return func(info *LogInfoNode) (map[string]string, error) {
+			validProperties := make(map[string]bool)
+			for _, property := range properties {
+				validProperties[property] = true
+			}
+			ret := make(map[string]string)
+			for k, v := range info.children {
+				if _, ok := validProperties[k]; !ok {
+					return nil, fmt.Errorf("%s is not a valid properties for format %s", k, info.value)
+				}
+				ret[k] = v.value
+			}
+			return ret, nil
+		}
+	}
+
+	Register("none", simpleConverter([]string{}))
+	Register("csv", simpleConverter([]string{"time_key", "time_format", "keys"}))
+	Register("json", simpleConverter([]string{"time_key", "time_format"}))
+	Register("regexp", simpleConverter([]string{"time_key", "time_format", }))
+	Register("apache2", simpleConverter([]string{}))
+	Register("apache_error", simpleConverter([]string{}))
+	Register("nginx", simpleConverter([]string{}))
+	Register("regexp", func(info *LogInfoNode) (map[string]string, error) {
+		ret, err := simpleConverter([]string{"pattern", "time_format"})(info)
+		if err != nil {
+			return ret, err
+		}
+		if ret["pattern"] == "" {
+			return nil, fmt.Errorf("regex pattern can not be emtpy")
+		}
+		return ret, nil
+	})
+}
+


### PR DESCRIPTION
1. code refactor
2. add regexp log format
3. add aliyun.logs.name.format.xxx extend config
4. add time_key, time_format, keys configure to csv format
5. add time_key, time_format configure to json format
6. fix unittest fails