### PR TITLE
fix-version-requirment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Try it
 Prerequisites:
 
 - docker-compose >= 1.6
-- Docker Engine >= 1.6
+- Docker Engine >= 1.10
 
 ```
 git clone git@github.com:jzwlqx/fluentd-pilot.git


### PR DESCRIPTION
compose version 2 require docker engine version above 1.10:
https://github.com/docker/compose/releases/1.6.0